### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL scheme check

### DIFF
--- a/src/utils/security/sanitization.ts
+++ b/src/utils/security/sanitization.ts
@@ -18,6 +18,7 @@ export const sanitizeHtml = (unsafeString: string): string => {
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#039;')
     .replace(/javascript:/gi, 'removed:')
+    .replace(/vbscript:/gi, 'removed:') // Prevent vbscript: URLs which can be used for XSS
     .replace(/on\w+=/gi, 'data-removed=')
     .replace(/data:/gi, 'removed:'); // Prevent data: URLs which can be used for XSS
 };
@@ -70,6 +71,7 @@ export const sanitizeHtmlAttribute = (attributeValue: string): string => {
     .replace(/>/g, '&gt;')
     .replace(/</g, '&lt;')
     .replace(/javascript:/gi, 'removed:')
+    .replace(/vbscript:/gi, 'removed:') // Prevent vbscript: URLs which can be used for XSS
     .replace(/data:/gi, 'removed:');
 };
 


### PR DESCRIPTION
Potential fix for [https://github.com/alschell/wealthhorizon/security/code-scanning/1](https://github.com/alschell/wealthhorizon/security/code-scanning/1)

To fix the issue, we need to extend the sanitization logic in the `sanitizeHtml` function to also replace occurrences of the `vbscript:` scheme with `removed:`. This will ensure that all known dangerous URL schemes (`javascript:`, `data:`, and `vbscript:`) are handled consistently. The change should be made on line 20 of the `sanitizeHtml` function. Additionally, we should update the `sanitizeHtmlAttribute` function on line 72 to include the same check for `vbscript:` for consistency.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
